### PR TITLE
Prevent app from dying of fork exit

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -85,6 +85,7 @@ def run_export(images_json)
   key = params[:key] || ''
 
   pid = fork do
+    settings.running_server = nil
     MapKnitterExporter.run_export(
       id, # sources from first image
       scale,


### PR DESCRIPTION
Forked process was causing Sinatra to exit. This prevents it (from https://stackoverflow.com/questions/38934398/process-detach-cause-sinatra-1-4-7-auto-exit/38934866#38934866)