### PR TITLE
output full status.json

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -144,16 +144,26 @@ class Export
 
     @directory.files.create(
       :key    => "#{@export_id}/status.json",
-      :body   => @status,
+      :body   => to_json,
       :public => true
     )
     STDERR.puts "saved"
+
+    # should run only if jpg completed:
     if @status == "complete"
       @directory.files.create(
         :key    => "#{@export_id}/#{@export_id}.jpg",
         :body   => File.open(@jpg),
         :public => true
       )
+    # elsif @status == "generating jpg" # tiles have been zipped
+    #   # save zip
+    # elsif @status == "zipping tiles" # tiles have been generated
+    #   # save tms
+    # elsif @status == "tiling" # images have been composited into single image
+    #   # save geotiff
+    # elsif @status == "compositing" # individual images have been distorted
+    #   # save individual images? (optional)
     end
     return true
   end


### PR DESCRIPTION
instead of just "status" field; this will expose the export artifacts' URLs

Also, if there's a way to pass the static location of status.json we should; we could also include its own location in the status.json file, so we only have to call its dynamic route once. 

I also commented where we should begin storing the other export output artifacts like `zip`, `tms`, `geotiff`, etc.