### PR TITLE
fixes for uploading files, status.json

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem "nokogiri"
 
 gem "fog-google"
 gem "fog-local"
-gem "mapknitter-exporter", "~>1.0.2"
+gem "mapknitter-exporter", "~>1.0.3"
 
 group :test do
   gem "rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,7 @@ GEM
       signet (~> 0.7)
     httpclient (2.8.3)
     jwt (2.1.0)
+    mapknitter-exporter (1.0.3)
     memoist (0.16.0)
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
@@ -53,7 +54,6 @@ GEM
     mini_portile2 (2.4.0)
     multi_json (1.13.1)
     multipart-post (2.0.0)
-    mapknitter-exporter (1.0.2)
     mustermann (1.0.3)
     nokogiri (1.10.0)
       mini_portile2 (~> 2.4.0)
@@ -101,8 +101,8 @@ PLATFORMS
 DEPENDENCIES
   fog-google
   fog-local
+  mapknitter-exporter (~> 1.0.3)
   nokogiri
-  mapknitter-exporter (~> 1.0.2)
   rack-test
   rspec
   sinatra

--- a/app.rb
+++ b/app.rb
@@ -31,18 +31,27 @@ get '/jpg' do
   send_file "public/warps/#{params[:id]}/#{params[:id]}.jpg"
 end
 
+# status.json records:
+# http://export.mapknitter.org/public/warps/13015/13015-geo.tif
+# 
+# but this route says it should be at:
+# http://export.mapknitter.org/id/13015/13015-geo.tif
+# http://export.mapknitter.org/id/13015/13015.jpg
+#
+# it actually is at:
+# http://export.mapknitter.org/id/1557020467/1557020467.jpg
+#
+# ideally we want (but are OK with this redirect):
+# https://storage.cloud.google.com/mapknitter-exports-warps/13015/13015.jpg
+# 
 # Show files
 get '/id/:export_id/:filename' do
-  connection = Fog::Storage.new( YAML.load(ERB.new(File.read('files.yml')).result) )
+  connection = Fog::Storage.new(YAML.load(ERB.new(File.read('files.yml')).result))
 
-  # First, a place to contain the glorious details
   directory = connection.directories.get("mapknitter-exports-warps")
   stat = directory.files.get("#{params[:export_id]}/#{params[:filename]}")
 
-  if stat
-    public_url = "https://storage.cloud.google.com/mapknitter-exports-warps/#{params[:export_id]}/#{params[:filename]}"
-    redirect public_url
-  end
+  redirect stat.public_url
 end
 
 get '/export' do
@@ -80,20 +89,19 @@ def run_export(images_json)
   end
 
   scale = params[:scale] || images_json[0]['cm_per_pixel']
-  map_id = params[:map_id] || images_json[0]['map_id']
-  id = params[:id] || images_json[0]['id']
+  user_id = params[:user_id] || images_json[0]['user_id']
   key = params[:key] || ''
 
+  `mkdir public/warps`
   pid = fork do
     settings.running_server = nil
     MapKnitterExporter.run_export(
-      export.export_id,
+      user_id, # user_id, unused
       scale,
       export,
-      map_id,
+      export.export_id,
       images_json,
-      key,
-      map_id # redundant, collection_id, see https://github.com/publiclab/mapknitter-exporter/issues/21
+      key
     )
   end
   Process.detach(pid)
@@ -135,20 +143,6 @@ class Export
 
 
   def save
-    # need to save status.json file with above properties as strings
-    if @directory.files.head("#{@export_id}/status.json")
-      sleep 2  # or we hit "Too many requests"
-      stat = @directory.files.get("#{@export_id}/status.json")
-      stat.destroy
-    end
-
-    @directory.files.create(
-      :key    => "#{@export_id}/status.json",
-      :body   => to_json,
-      :public => true
-    )
-    STDERR.puts "saved status.json"
-
     if @status == "complete"
       save_file(@jpg, 'jpg', @export_id)
     elsif @status == "generating jpg" # tiles have been zipped
@@ -162,9 +156,26 @@ class Export
     # elsif @status == "compositing" # individual images have been distorted
     #   # save individual images? (optional)
     end
+
+    # need to save status.json file with above properties as strings
+    if @directory.files.head("#{@export_id}/status.json")
+      sleep 2  # or we hit "Too many requests"
+      stat = @directory.files.get("#{@export_id}/status.json")
+      # record a static URL for status.json:
+      @status_url = stat.public_url
+      stat.destroy
+    end
+
+    @directory.files.create(
+      :key    => "#{@export_id}/status.json",
+      :body   => to_json,
+      :public => true
+    )
+    STDERR.puts "saved status.json"
     return true
   end
-  
+
+  # TODO: save the static path instead of the sinatra-redirected path, into status.json 
   def save_file(path, extension, id)
     key = "#{id}/#{id}.#{extension}"
     file = @directory.files.create(

--- a/app.rb
+++ b/app.rb
@@ -31,19 +31,6 @@ get '/jpg' do
   send_file "public/warps/#{params[:id]}/#{params[:id]}.jpg"
 end
 
-# status.json records:
-# http://export.mapknitter.org/public/warps/13015/13015-geo.tif
-# 
-# but this route says it should be at:
-# http://export.mapknitter.org/id/13015/13015-geo.tif
-# http://export.mapknitter.org/id/13015/13015.jpg
-#
-# it actually is at:
-# http://export.mapknitter.org/id/1557020467/1557020467.jpg
-#
-# ideally we want (but are OK with this redirect):
-# https://storage.cloud.google.com/mapknitter-exports-warps/13015/13015.jpg
-# 
 # Show files
 get '/id/:export_id/:filename' do
   connection = Fog::Storage.new(YAML.load(ERB.new(File.read('files.yml')).result))

--- a/spec/landing_spec.rb
+++ b/spec/landing_spec.rb
@@ -32,4 +32,10 @@ describe "Mapknitter Exporter" do
     get "/export?url=https://mapknitter.org/maps/ceres--2/warpables.json&scale=30"
     expect(last_response.body).to match("/status.json") # we won't be able to get the exact Time.now.to_i
   end
+
+  #it "tests with mocked cloud upload" do
+  #  Fog.mock!
+  #  get "/export?url=https://mapknitter.org/maps/ceres--2/warpables.json&scale=30"
+  #end
+
 end


### PR DESCRIPTION
Fix for:

```

# status.json records:
# http://export.mapknitter.org/public/warps/13015/13015-geo.tif
# 
# but this route says it should be at:
# http://export.mapknitter.org/id/13015/13015-geo.tif
# http://export.mapknitter.org/id/13015/13015.jpg
#
# it actually is at:
# http://export.mapknitter.org/id/1557020467/1557020467.jpg
#
# ideally we want (but are OK with this redirect):
# https://storage.cloud.google.com/mapknitter-exports-warps/13015/13015.jpg
# 
```